### PR TITLE
Fix to wire obstruction detection resolves #17

### DIFF
--- a/src/main/java/de/sanandrew/mods/immersivecables/item/ItemCoil.java
+++ b/src/main/java/de/sanandrew/mods/immersivecables/item/ItemCoil.java
@@ -142,10 +142,10 @@ public class ItemCoil
                                         ignore.addAll(nodeLink.getIgnored(nodeHere));
                                         ImmersiveNetHandler.Connection tmpConn = new ImmersiveNetHandler.Connection(Utils.toCC(nodeHere), Utils.toCC(nodeLink), wire,
                                                                                                                     (int) Math.sqrt(distanceSq));
-                                        Vec3d start = nodeHere.getConnectionOffset(tmpConn, target, pos.subtract(masterPos)).addVector(tile.getPos().getX(),
-                                                                                                                                       tile.getPos().getY(), tile.getPos().getZ());
-                                        Vec3d end = nodeLink.getConnectionOffset(tmpConn, targetLink, offsetLink).addVector(tileEntityLinkingPos.getPos().getX(),
-                                                                                                                            tileEntityLinkingPos.getPos().getY(), tileEntityLinkingPos.getPos().getZ());
+                                        Vec3d start = nodeHere.getConnectionOffset(tmpConn, target, pos.subtract(masterPos));
+					Vec3d end = nodeLink.getConnectionOffset(tmpConn, targetLink, offsetLink).addVector(linkPos.getX()-masterPos.getX(),
+											linkPos.getY()-masterPos.getY(),
+											linkPos.getZ()-masterPos.getZ());
                                         boolean canSee = ApiUtils.raytraceAlongCatenaryRelative(tmpConn, (p) -> {
                                             if (ignore.contains(p.getLeft())) {
                                                 return false;


### PR DESCRIPTION
Will no longer allow wires through walls and allows legitimate connections, essentially the intended behaviour or IE's ray trace for wire obstruction detection.